### PR TITLE
When using only the image name in docker command, it fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ docker pull augmentable/askgit:latest
 > [**pwd**] Print the absolute pathname of the current working directory.
 
 ```
-docker run -v `pwd`:/repo:ro askgit "SELECT * FROM commits"
+docker run -v `pwd`:/repo:ro augmentable/askgit "SELECT * FROM commits"
 ```
 
 #### Running commands from STDIN
@@ -69,7 +69,7 @@ docker run -v `pwd`:/repo:ro askgit "SELECT * FROM commits"
 For piping commands via STDIN, the docker command needs to be told to run non-interactively, as well as attaching the repository at `/repo`.
 
 ```
-cat query.sql | docker run -i -v `pwd`:/repo:ro askgit
+cat query.sql | docker run -i -v `pwd`:/repo:ro augmentable/askgit
 ```
 
 ## Usage


### PR DESCRIPTION
When using only the image name in docker command, it fails with a `Unable to find image 'askgit:latest' locally`

Adding the owner to the docker image (as `augmentable/askgit`) solves the issue.