### PR TITLE
loads a helper function for splitting strings

### DIFF
--- a/pkg/gitqlite/gitqlite.go
+++ b/pkg/gitqlite/gitqlite.go
@@ -48,6 +48,11 @@ func init() {
 				return err
 			}
 
+			err = loadHelperFuncs(conn)
+			if err != nil {
+				return err
+			}
+
 			return nil
 		},
 	})
@@ -104,6 +109,23 @@ func (g *GitQLite) ensureTables(options *Options) error {
 	}
 	_, err = g.DB.Exec(fmt.Sprintf("CREATE VIRTUAL TABLE IF NOT EXISTS branches USING git_branch('%s');", g.RepoPath))
 	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func loadHelperFuncs(conn *sqlite3.SQLiteConn) error {
+	// str_split(inputString, splitCharacter, index) string
+	split := func(s, c string, i int) string {
+		split := strings.Split(s, c)
+		if i < len(split) {
+			return split[i]
+		}
+		return ""
+	}
+
+	if err := conn.RegisterFunc("str_split", split, true); err != nil {
 		return err
 	}
 

--- a/pkg/gitqlite/helpers_test.go
+++ b/pkg/gitqlite/helpers_test.go
@@ -1,0 +1,39 @@
+package gitqlite
+
+import (
+	"testing"
+)
+
+func TestStrSplit(t *testing.T) {
+	instance, err := New(fixtureRepoDir, &Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := instance.DB.Query("SELECT str_split('hello world', ' ', 0)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rowNum, contents, err := GetContents(rows)
+	if err != nil {
+		t.Fatalf("err %d at row Number %d", err, rowNum)
+	}
+
+	if contents[0][0] != "hello" {
+		t.Fatalf("expected string: %s, got %s", "hello", contents[0][0])
+	}
+
+
+	rows, err = instance.DB.Query("SELECT str_split('hello world', ' ', 10)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rowNum, contents, err = GetContents(rows)
+	if err != nil {
+		t.Fatalf("err %d at row Number %d", err, rowNum)
+	}
+
+	if contents[0][0] != "" {
+		t.Fatalf("expected string: %s, got %s", "", contents[0][0])
+	}
+}


### PR DESCRIPTION
I've had difficulty splitting strings using the built-in sqlite str functions, this is a helper to make splitting strings in queries more succinct. The use case I have in mind, is when dealing with semver tag names such as `v1.2.3`, this makes it a little easier to pull out the components of a semver string (and therefore sort on it)