### PR TITLE
SSH cloning

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,8 +89,8 @@ var rootCmd = &cobra.Command{
 				// https://github.com/libgit2/git2go/commit/36e0a256fe79f87447bb730fda53e5cbc90eb47c
 				cloneOptions.FetchOptions = &git.FetchOptions{
 					RemoteCallbacks: git.RemoteCallbacks{
-						CredentialsCallback:      credentialsCallback,
-						CertificateCheckCallback: certificateCheckCallback,
+						CredentialsCallback:      CredentialsCallback,
+						CertificateCheckCallback: CertificateCheckCallback,
 					}}
 				dir, err = ioutil.TempDir("", "repo")
 				handleError(err)
@@ -148,7 +148,7 @@ func readStdin() (string, error) {
 	returnString := string(output)
 	return returnString, nil
 }
-func credentialsCallback(url string, username string, allowedTypes git.CredType) (*git.Cred, error) {
+func CredentialsCallback(url string, username string, allowedTypes git.CredType) (*git.Cred, error) {
 	usr, _ := user.Current()
 	publicSSH := usr.HomeDir + "/.ssh/id_rsa.pub"
 	privateSSH := usr.HomeDir + "/.ssh/id_rsa"
@@ -157,6 +157,6 @@ func credentialsCallback(url string, username string, allowedTypes git.CredType)
 }
 
 // Made this one just return 0 during troubleshooting...
-func certificateCheckCallback(cert *git.Certificate, valid bool, hostname string) git.ErrorCode {
+func CertificateCheckCallback(cert *git.Certificate, valid bool, hostname string) git.ErrorCode {
 	return 0
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ func init() {
 func handleError(err error) {
 	if err != nil {
 		fmt.Println(err)
-		panic(err)
+		os.Exit(1)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 	"path/filepath"
 
 	"github.com/augmentable-dev/askgit/pkg/gitqlite"
@@ -34,7 +35,7 @@ func init() {
 func handleError(err error) {
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		panic(err)
 	}
 }
 
@@ -83,10 +84,17 @@ var rootCmd = &cobra.Command{
 		// if the repo can be parsed as a remote git url, clone it to a temporary directory and use that as the repo path
 		if remote, err := vcsurl.Parse(repo); err == nil { // if it can be parsed
 			if r, err := remote.Remote(vcsurl.HTTPS); err == nil { // if it can be resolved into an HTTPS remote
+				cloneOptions := &git.CloneOptions{}
+				// use FetchOptions instead of directly RemoteCallbacks
+				// https://github.com/libgit2/git2go/commit/36e0a256fe79f87447bb730fda53e5cbc90eb47c
+				cloneOptions.FetchOptions = &git.FetchOptions{
+					RemoteCallbacks: git.RemoteCallbacks{
+						CredentialsCallback:      credentialsCallback,
+						CertificateCheckCallback: certificateCheckCallback,
+					}}
 				dir, err = ioutil.TempDir("", "repo")
 				handleError(err)
-
-				_, err = git.Clone(r, dir, &git.CloneOptions{})
+				_, err = git.Clone(r, dir, cloneOptions)
 				handleError(err)
 
 				defer func() {
@@ -96,11 +104,13 @@ var rootCmd = &cobra.Command{
 
 			}
 		}
+
 		if dir == "" {
 			dir, err = filepath.Abs(repo)
 		} else {
 			dir, err = filepath.Abs(dir)
 		}
+
 		if err != nil {
 			handleError(err)
 		}
@@ -115,7 +125,6 @@ var rootCmd = &cobra.Command{
 
 		rows, err := g.DB.Query(query)
 		handleError(err)
-
 		err = gitqlite.DisplayDB(rows, os.Stdout, format)
 		handleError(err)
 	},
@@ -138,4 +147,16 @@ func readStdin() (string, error) {
 	}
 	returnString := string(output)
 	return returnString, nil
+}
+func credentialsCallback(url string, username string, allowedTypes git.CredType) (*git.Cred, error) {
+	usr, _ := user.Current()
+	publicSSH := usr.HomeDir + "/.ssh/id_rsa.pub"
+	privateSSH := usr.HomeDir + "/.ssh/id_rsa"
+	cred, ret := git.NewCredSshKey("git", publicSSH, privateSSH, "")
+	return cred, ret
+}
+
+// Made this one just return 0 during troubleshooting...
+func certificateCheckCallback(cert *git.Certificate, valid bool, hostname string) git.ErrorCode {
+	return 0
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,7 +103,7 @@ var rootCmd = &cobra.Command{
 							return cred, ret
 						},
 						CertificateCheckCallback: func(cert *git.Certificate, valid bool, hostname string) git.ErrorCode {
-							return 0
+							return git.ErrOk
 						},
 					}}
 			}

--- a/pkg/gitqlite/gitqlite_test.go
+++ b/pkg/gitqlite/gitqlite_test.go
@@ -4,11 +4,9 @@ import (
 	"database/sql"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"testing"
 
 	git "github.com/libgit2/git2go/v30"
-	//"github.com/augmentable-dev/askgit/cmd"
 )
 
 var (
@@ -17,18 +15,6 @@ var (
 	fixtureRepoDir      string
 )
 
-func CredentialsCallback(url string, username string, allowedTypes git.CredType) (*git.Cred, error) {
-	usr, _ := user.Current()
-	publicSSH := usr.HomeDir + "/.ssh/id_rsa.pub"
-	privateSSH := usr.HomeDir + "/.ssh/id_rsa"
-	cred, ret := git.NewCredSshKey("git", publicSSH, privateSSH, "")
-	return cred, ret
-}
-
-// Made this one just return 0 during troubleshooting...
-func CertificateCheckCallback(cert *git.Certificate, valid bool, hostname string) git.ErrorCode {
-	return 0
-}
 func TestMain(m *testing.M) {
 	close, err := initFixtureRepo()
 	if err != nil {
@@ -44,15 +30,7 @@ func initFixtureRepo() (func() error, error) {
 	if err != nil {
 		return nil, err
 	}
-	cloneOptions := &git.CloneOptions{}
-	// use FetchOptions instead of directly RemoteCallbacks
-	// https://github.com/libgit2/git2go/commit/36e0a256fe79f87447bb730fda53e5cbc90eb47c
-	cloneOptions.FetchOptions = &git.FetchOptions{
-		RemoteCallbacks: git.RemoteCallbacks{
-			CredentialsCallback:      CredentialsCallback,
-			CertificateCheckCallback: CertificateCheckCallback,
-		}}
-	fixtureRepo, err = git.Clone(fixtureRepoCloneURL, dir, cloneOptions)
+	fixtureRepo, err = git.Clone(fixtureRepoCloneURL, dir, &git.CloneOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gitqlite/helpers_test.go
+++ b/pkg/gitqlite/helpers_test.go
@@ -23,7 +23,6 @@ func TestStrSplit(t *testing.T) {
 		t.Fatalf("expected string: %s, got %s", "hello", contents[0][0])
 	}
 
-
 	rows, err = instance.DB.Query("SELECT str_split('hello world', ' ', 10)")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Use the user's default ssh key when cloning via SSH. Should close #59 