### PR TITLE
modification to how github table filter and best index works

### DIFF
--- a/pkg/ghqlite/repos_vtab.go
+++ b/pkg/ghqlite/repos_vtab.go
@@ -2,7 +2,6 @@ package ghqlite
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -37,7 +36,7 @@ func (m *ReposModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab
 		CREATE TABLE %s (
 			repo_owner HIDDEN,
 			id INT,
-			node_id TEXT,
+			node_id TEXT PRIMARY KEY,
 			name TEXT,
 			full_name TEXT,
 			owner TEXT,
@@ -63,7 +62,7 @@ func (m *ReposModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab
 			created_at DATETIME,
 			updated_at DATETIME,
 			permissions TEXT
-		)`, args[0]))
+		) WITHOUT ROWID`, args[0]))
 	if err != nil {
 		return nil, err
 	}
@@ -167,33 +166,36 @@ func (vc *reposCursor) Column(c *sqlite3.SQLiteContext, col int) error {
 
 func (v *reposTable) BestIndex(constraints []sqlite3.InfoConstraint, ob []sqlite3.InfoOrderBy) (*sqlite3.IndexResult, error) {
 	used := make([]bool, len(constraints))
+	cost := 1000.0
 	repoOwnerCstUsed := false
 	for c, cst := range constraints {
+		if !cst.Usable {
+			continue
+		}
+		if cst.Op != sqlite3.OpEQ {
+			continue
+		}
 		switch cst.Column {
 		case 0: // repo_owner
-			if cst.Op != sqlite3.OpEQ { // if there's no equality constraint, fail
-				return nil, sqlite3.ErrConstraint
-			}
-			// if the constraint is usable, use it, otherwise fail
-			if used[c] = cst.Usable; !used[c] {
-				return nil, sqlite3.ErrConstraint
-			}
+			used[c] = true
 			repoOwnerCstUsed = true
 		}
 	}
 
-	if !repoOwnerCstUsed {
-		return nil, errors.New("must supply a repo owner")
+	if repoOwnerCstUsed {
+		cost = 0
 	}
 
 	return &sqlite3.IndexResult{
-		IdxNum: 0,
-		IdxStr: "default",
-		Used:   used,
+		IdxNum:        0,
+		IdxStr:        "default",
+		Used:          used,
+		EstimatedCost: cost,
 	}, nil
 }
 
 func (vc *reposCursor) Filter(idxNum int, idxStr string, vals []interface{}) error {
+	vc.eof = false
 	owner := vals[0].(string)
 	iter := NewRepoIterator(owner, vc.table.module.ownerType, GitHubIteratorOptions{
 		Token:        vc.table.module.options.Token,


### PR DESCRIPTION
fixes a bug to now allow queries like:

```
SELECT repo.*, pr.* FROM github_org_repos("augmentable-dev") repo, github_pull_requests("augmentable-dev", name) pr
```