### PR TITLE
Make it easier (possible) to export tables into a sqlite db

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,3 +348,16 @@ askgit --interactive
 ```
 
 Will display a basic terminal UI for composing and executing queries, powered by [gocui](https://github.com/jroimartin/gocui).
+
+#### Exporting
+
+You can use the `askgit export` sub command to save the output of queries into a sqlite database file.
+The command expects a path to a db file (which will be created if it doesn't already exist) and a variable number of "export pairs," specified by the `-e` flag.
+Each pair represents the name of a table to create and a query to generate its contents.
+
+```
+askgit export my-export-file -e commits,"SELECT * FROM commits" -e files,"SELECT * FROM files"
+```
+
+This can be useful if you're looking to use another tool to examine the data emitted by `askgit`.
+Since the exported file is a plain SQLite database, queries should be much faster (as the original git repository is no longer traversed) and you should be able to use any tool that supports querying SQLite database files.

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -50,13 +50,13 @@ var exportCmd = &cobra.Command{
 
 		dir := determineRepo()
 
-		ag, err := askgit.New(dir, &askgit.Options{
+		ag, err := askgit.New(&askgit.Options{
+			RepoPath:    dir,
 			UseGitCLI:   useGitCLI,
 			GitHubToken: os.Getenv("GITHUB_TOKEN"),
 			DBFilePath:  exportFile,
 		})
 		handleError(err)
-		defer ag.Close()
 
 		for _, pair := range pairs {
 			s := fmt.Sprintf("CREATE TABLE %s AS %s", pair.table, pair.query)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/augmentable-dev/askgit/pkg/askgit"
+	"github.com/spf13/cobra"
+)
+
+var (
+	exports []string
+)
+
+type export struct {
+	table string
+	query string
+}
+
+func init() {
+	exportCmd.Flags().StringSliceVarP(&exports, "exports", "e", []string{}, "queries to export, supplied as string pairs")
+}
+
+var exportCmd = &cobra.Command{
+	Use:  "export [sqlite db file]",
+	Long: `Use this command to export queries into a SQLite database file on disk`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(exports) == 0 {
+			handleError(errors.New("please supply at least one export pair"))
+		}
+
+		if len(exports)%2 != 0 {
+			handleError(fmt.Errorf("expected even number of export pairs, got %d", len(exports)))
+		}
+
+		pairs := make([]export, len(exports)/2)
+		for e := 0; e < len(exports)-1; e += 2 {
+			if e == 0 {
+				pairs[e] = export{exports[e], exports[e+1]}
+			} else {
+				pairs[e-1] = export{exports[e], exports[e+1]}
+			}
+		}
+
+		exportFile, err := filepath.Abs(args[0])
+		handleError(err)
+
+		dir := determineRepo()
+
+		ag, err := askgit.New(dir, &askgit.Options{
+			UseGitCLI:   useGitCLI,
+			GitHubToken: os.Getenv("GITHUB_TOKEN"),
+			DBFilePath:  exportFile,
+		})
+		handleError(err)
+		defer ag.Close()
+
+		for _, pair := range pairs {
+			s := fmt.Sprintf("CREATE TABLE %s AS %s", pair.table, pair.query)
+
+			_, err := ag.DB().Exec(s)
+			handleError(err)
+		}
+
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,12 +113,12 @@ var rootCmd = &cobra.Command{
 
 		dir := determineRepo()
 
-		ag, err := askgit.New(dir, &askgit.Options{
+		ag, err := askgit.New(&askgit.Options{
+			RepoPath:    dir,
 			UseGitCLI:   useGitCLI,
 			GitHubToken: os.Getenv("GITHUB_TOKEN"),
 		})
 		handleError(err)
-		defer ag.Close()
 
 		if cui {
 			tui.RunGUI(ag, query)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,11 +24,17 @@ var (
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&repo, "repo", ".", "path to git repository (defaults to current directory). A remote repo may be specified, it will be cloned to a temporary directory before query execution.")
-	rootCmd.PersistentFlags().StringVar(&format, "format", "table", "specify the output format. Options are 'csv' 'tsv' 'table' 'single' and 'json'")
+	// global flags
+	rootCmd.PersistentFlags().StringVarP(&repo, "repo", "r", ".", "path to git repository (defaults to current directory).\nA remote repo may be specified, it will be cloned to a temporary directory before query execution.")
 	rootCmd.PersistentFlags().BoolVar(&useGitCLI, "use-git-cli", false, "whether to use the locally installed git command (if it's available). Defaults to false.")
-	rootCmd.PersistentFlags().BoolVarP(&cui, "interactive", "i", false, "whether to run in interactive mode, which displays a terminal UI")
-	rootCmd.PersistentFlags().StringVar(&presetQuery, "preset", "", "used to pick a preset query")
+
+	// local (root command only) flags
+	rootCmd.Flags().StringVarP(&format, "format", "f", "table", "specify the output format. Options are 'csv' 'tsv' 'table' 'single' and 'json'")
+	rootCmd.Flags().BoolVarP(&cui, "interactive", "i", false, "whether to run in interactive mode, which displays a terminal UI")
+	rootCmd.Flags().StringVarP(&presetQuery, "preset", "p", "", "used to pick a preset query")
+
+	// add the export sub command
+	rootCmd.AddCommand(exportCmd)
 }
 
 func handleError(err error) {
@@ -38,24 +44,50 @@ func handleError(err error) {
 	}
 }
 
+func determineRepo() string {
+	// the directory on disk of the repository
+	var dir string
+
+	cwd, err := os.Getwd()
+	handleError(err)
+
+	// if a repo path is not supplied as a flag, use the current directory
+	if repo == "" {
+		repo = cwd
+	}
+
+	// if the repo can be parsed as a remote git url, clone it to a temporary directory and use that as the repo path
+	if remote, err := vcsurl.Parse(repo); err == nil { // if it can be parsed
+		dir, err = ioutil.TempDir("", "repo")
+		handleError(err)
+
+		cloneOptions := askgit.CreateAuthenticationCallback(remote)
+		_, err = git.Clone(repo, dir, cloneOptions)
+		handleError(err)
+
+		dir, err = filepath.Abs(dir)
+		handleError(err)
+
+		defer func() {
+			err := os.RemoveAll(dir)
+			handleError(err)
+		}()
+	} else {
+		dir, err = filepath.Abs(repo)
+		handleError(err)
+	}
+
+	return dir
+}
+
 var rootCmd = &cobra.Command{
-	Use: `askgit "SELECT * FROM commits"`,
+	Use:  `askgit "SELECT * FROM commits"`,
+	Args: cobra.MaximumNArgs(2),
 	Long: `
   askgit is a CLI for querying git repositories with SQL, using SQLite virtual tables.
   Example queries can be found in the GitHub repo: https://github.com/augmentable-dev/askgit`,
 	Short: `query your github repos with SQL`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cwd, err := os.Getwd()
-		handleError(err)
-
-		// if a repo path is not supplied as a flag, use the current directory
-		if repo == "" {
-			if len(args) > 1 {
-				repo = args[1]
-			} else {
-				repo = cwd
-			}
-		}
 		info, err := os.Stdin.Stat()
 		handleError(err)
 
@@ -78,37 +110,15 @@ var rootCmd = &cobra.Command{
 			handleError(err)
 			os.Exit(0)
 		}
-		var dir string
 
-		// if the repo can be parsed as a remote git url, clone it to a temporary directory and use that as the repo path
-		if remote, err := vcsurl.Parse(repo); err == nil { // if it can be parsed
-			dir, err = ioutil.TempDir("", "repo")
-			handleError(err)
-			cloneOptions := askgit.CreateAuthenticationCallback(remote)
-			_, err = git.Clone(repo, dir, cloneOptions)
-			handleError(err)
-
-			defer func() {
-				err := os.RemoveAll(dir)
-				handleError(err)
-			}()
-		}
-
-		if dir == "" {
-			dir, err = filepath.Abs(repo)
-		} else {
-			dir, err = filepath.Abs(dir)
-		}
-
-		if err != nil {
-			handleError(err)
-		}
+		dir := determineRepo()
 
 		ag, err := askgit.New(dir, &askgit.Options{
 			UseGitCLI:   useGitCLI,
 			GitHubToken: os.Getenv("GITHUB_TOKEN"),
 		})
 		handleError(err)
+		defer ag.Close()
 
 		if cui {
 			tui.RunGUI(ag, query)

--- a/pkg/askgit/helpers_test.go
+++ b/pkg/askgit/helpers_test.go
@@ -5,11 +5,10 @@ import (
 )
 
 func TestStrSplit(t *testing.T) {
-	ag, err := New(fixtureRepoDir, &Options{})
+	ag, err := New(&Options{RepoPath: fixtureRepoDir})
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ag.Close()
 
 	rows, err := ag.DB().Query("SELECT str_split('hello world', ' ', 0)")
 	if err != nil {

--- a/pkg/askgit/helpers_test.go
+++ b/pkg/askgit/helpers_test.go
@@ -9,6 +9,7 @@ func TestStrSplit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ag.Close()
 
 	rows, err := ag.DB().Query("SELECT str_split('hello world', ' ', 0)")
 	if err != nil {

--- a/pkg/gitqlite/git_branches.go
+++ b/pkg/gitqlite/git_branches.go
@@ -7,15 +7,23 @@ import (
 	"github.com/mattn/go-sqlite3"
 )
 
-type GitBranchesModule struct{}
+type GitBranchesModule struct {
+	options *GitBranchesModuleOptions
+}
 
-func NewGitBranchesModule() *GitBranchesModule {
-	return &GitBranchesModule{}
+type GitBranchesModuleOptions struct {
+	RepoPath string
+}
+
+func NewGitBranchesModule(options *GitBranchesModuleOptions) *GitBranchesModule {
+	return &GitBranchesModule{options}
 }
 
 type gitBranchesTable struct {
 	repoPath string
 }
+
+func (m *GitBranchesModule) EponymousOnlyModule() {}
 
 func (m *GitBranchesModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab, error) {
 	err := c.DeclareVTab(fmt.Sprintf(`
@@ -29,10 +37,7 @@ func (m *GitBranchesModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite
 		return nil, err
 	}
 
-	// the repoPath will be enclosed in double quotes "..." since ensureTables uses %q when setting up the table
-	// we need to pop those off when referring to the actual directory in the fs
-	repoPath := args[3][1 : len(args[3])-1]
-	return &gitBranchesTable{repoPath: repoPath}, nil
+	return &gitBranchesTable{repoPath: m.options.RepoPath}, nil
 }
 
 func (m *GitBranchesModule) Connect(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab, error) {

--- a/pkg/gitqlite/git_files.go
+++ b/pkg/gitqlite/git_files.go
@@ -9,16 +9,24 @@ import (
 	"github.com/mattn/go-sqlite3"
 )
 
-type GitFilesModule struct{}
+type GitFilesModule struct {
+	options *GitFilesModuleOptions
+}
 
-func NewGitFilesModule() *GitFilesModule {
-	return &GitFilesModule{}
+type GitFilesModuleOptions struct {
+	RepoPath string
+}
+
+func NewGitFilesModule(options *GitFilesModuleOptions) *GitFilesModule {
+	return &GitFilesModule{options}
 }
 
 type gitFilesTable struct {
 	repoPath string
 	repo     *git.Repository
 }
+
+func (m *GitFilesModule) EponymousOnlyModule() {}
 
 func (m *GitFilesModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab, error) {
 	err := c.DeclareVTab(fmt.Sprintf(`
@@ -33,8 +41,8 @@ func (m *GitFilesModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.V
 	if err != nil {
 		return nil, err
 	}
-	repoPath := args[3][1 : len(args[3])-1]
-	return &gitFilesTable{repoPath: repoPath}, nil
+
+	return &gitFilesTable{repoPath: m.options.RepoPath}, nil
 }
 
 func (m *GitFilesModule) Connect(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab, error) {

--- a/pkg/gitqlite/git_log.go
+++ b/pkg/gitqlite/git_log.go
@@ -8,10 +8,16 @@ import (
 	"github.com/mattn/go-sqlite3"
 )
 
-type GitLogModule struct{}
+type GitLogModule struct {
+	options *GitLogModuleOptions
+}
 
-func NewGitLogModule() *GitLogModule {
-	return &GitLogModule{}
+type GitLogModuleOptions struct {
+	RepoPath string
+}
+
+func NewGitLogModule(options *GitLogModuleOptions) *GitLogModule {
+	return &GitLogModule{options}
 }
 
 type gitLogTable struct {
@@ -19,9 +25,11 @@ type gitLogTable struct {
 	repo     *git.Repository
 }
 
+func (m *GitLogModule) EponymousOnlyModule() {}
+
 func (m *GitLogModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab, error) {
 	err := c.DeclareVTab(fmt.Sprintf(`
-		CREATE TABLE %q (
+		CREATE TABLE %s (
 			id TEXT,
 			message TEXT,
 			summary TEXT,
@@ -39,10 +47,7 @@ func (m *GitLogModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTa
 		return nil, err
 	}
 
-	// the repoPath will be enclosed in double quotes "..." since ensureTables uses %q when setting up the table
-	// we need to pop those off when referring to the actual directory in the fs
-	repoPath := args[3][1 : len(args[3])-1]
-	return &gitLogTable{repoPath: repoPath}, nil
+	return &gitLogTable{repoPath: m.options.RepoPath}, nil
 }
 
 func (m *GitLogModule) Connect(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab, error) {

--- a/pkg/gitqlite/git_log.go
+++ b/pkg/gitqlite/git_log.go
@@ -30,7 +30,7 @@ func (m *GitLogModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTa
 			author_when DATETIME,
 			committer_name TEXT,
 			committer_email TEXT,
-			committer_when DATETIME, 
+			committer_when DATETIME,
 			parent_id TEXT,
 			parent_count INT,
 			tree_id TEXT

--- a/pkg/gitqlite/git_log_cli.go
+++ b/pkg/gitqlite/git_log_cli.go
@@ -10,15 +10,23 @@ import (
 	"github.com/mattn/go-sqlite3"
 )
 
-type GitLogCLIModule struct{}
+type GitLogCLIModule struct {
+	options *GitLogCLIModuleOptions
+}
 
-func NewGitLogCLIModule() *GitLogCLIModule {
-	return &GitLogCLIModule{}
+type GitLogCLIModuleOptions struct {
+	RepoPath string
+}
+
+func NewGitLogCLIModule(options *GitLogCLIModuleOptions) *GitLogCLIModule {
+	return &GitLogCLIModule{options}
 }
 
 type gitLogCLITable struct {
 	repoPath string
 }
+
+func (m *GitLogCLIModule) EponymousOnlyModule() {}
 
 func (m *GitLogCLIModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab, error) {
 	err := c.DeclareVTab(fmt.Sprintf(`
@@ -40,10 +48,7 @@ func (m *GitLogCLIModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.
 		return nil, err
 	}
 
-	// the repoPath will be enclosed in double quotes "..." since ensureTables uses %q when setting up the table
-	// we need to pop those off when referring to the actual directory in the fs
-	repoPath := args[3][1 : len(args[3])-1]
-	return &gitLogCLITable{repoPath: repoPath}, nil
+	return &gitLogCLITable{repoPath: m.options.RepoPath}, nil
 }
 
 func (m *GitLogCLIModule) Connect(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab, error) {

--- a/pkg/gitqlite/git_stats.go
+++ b/pkg/gitqlite/git_stats.go
@@ -8,16 +8,24 @@ import (
 	"github.com/mattn/go-sqlite3"
 )
 
-type GitStatsModule struct{}
+type GitStatsModule struct {
+	options *GitStatsModuleOptions
+}
 
-func NewGitStatsModule() *GitStatsModule {
-	return &GitStatsModule{}
+type GitStatsModuleOptions struct {
+	RepoPath string
+}
+
+func NewGitStatsModule(options *GitStatsModuleOptions) *GitStatsModule {
+	return &GitStatsModule{options}
 }
 
 type gitStatsTable struct {
 	repoPath string
 	repo     *git.Repository
 }
+
+func (m *GitStatsModule) EponymousOnlyModule() {}
 
 func (m *GitStatsModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab, error) {
 	err := c.DeclareVTab(fmt.Sprintf(`
@@ -31,10 +39,7 @@ func (m *GitStatsModule) Create(c *sqlite3.SQLiteConn, args []string) (sqlite3.V
 		return nil, err
 	}
 
-	// the repoPath will be enclosed in double quotes "..." since ensureTables uses %q when setting up the table
-	// we need to pop those off when referring to the actual directory in the fs
-	repoPath := args[3][1 : len(args[3])-1]
-	return &gitStatsTable{repoPath: repoPath}, nil
+	return &gitStatsTable{repoPath: m.options.RepoPath}, nil
 }
 
 func (m *GitStatsModule) Connect(c *sqlite3.SQLiteConn, args []string) (sqlite3.VTab, error) {


### PR DESCRIPTION
Currently, something along the lines of:

```
askgit export my-db-file -e exported_commits,"SELECT * FROM commits" -e exported_branches,"SELECT * FROM branches"
```
Will create (or modify an existing) `my-db-file`, creating tables `exported_commits` and `exported_branches` as the corresponding query in the command.

Note that `commits` and `branches` already exist as tables, so exported tables need to have a new name (maybe this experience can be improved)
